### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Contributions welcome! Feel free to submit Pull Requests.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=fangyuan99/cookie-share&type=Date)](https://star-history.com/#fangyuan99/cookie-share&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=fangyuan99/cookie-share&type=Date)](https://star-history.dera.page/#fangyuan99/cookie-share&type=Date)
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -296,7 +296,7 @@ v0.4.1 将存储从 Cloudflare KV 切换到了 D1 数据库，数据格式不兼
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=fangyuan99/cookie-share&type=Date)](https://star-history.com/#fangyuan99/cookie-share&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=fangyuan99/cookie-share&type=Date)](https://star-history.dera.page/#fangyuan99/cookie-share&type=Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This fixes the chart links in README.md and README_CN.md so the project's growth is visible again.